### PR TITLE
Handle homepage calendar fetch errors

### DIFF
--- a/components/ToDo.tsx
+++ b/components/ToDo.tsx
@@ -1,7 +1,12 @@
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 
-const ToDo = ({ unparsedEvents }: { unparsedEvents: string }) => {
+interface ToDoProps {
+  unparsedEvents: string,
+  calendarLoadFailed: boolean,
+}
+
+const ToDo = ({ unparsedEvents, calendarLoadFailed }: ToDoProps) => {
 
   const [todo, setTodo] = useState<{ text: string, url: string }>({ text: "", url: "" })
 
@@ -29,7 +34,9 @@ const ToDo = ({ unparsedEvents }: { unparsedEvents: string }) => {
     <div className="font-theme drop-sh">
       <div className="text-3xl">Att göra:</div>
       <div className="text-5xl lg:text-7xl whitespace-nowrap">
-        {todo.url !== "" ?
+        {calendarLoadFailed ?
+          "Kalendern kunde inte hämtas"
+          : todo.url !== "" ?
           <Link href={todo.url}>
             <a>{todo.text} -&gt;</a>
           </Link>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,18 +21,30 @@ export const getServerSideProps = async () => {
   })
 
   const mottagningEventsUrl = mottagningenEventsLink?.url
+  let calendarLoadFailed = false
   const mottagningEvents = mottagningEventsUrl !== undefined
-    ? await ical.async.fromURL(mottagningEventsUrl)
+    ? await ical.async.fromURL(mottagningEventsUrl).catch(error => {
+      calendarLoadFailed = true
+      console.error(
+        `Failed to fetch homepage calendar: ${error instanceof Error ? error.message : String(error)}`
+      )
+      return undefined
+    })
     : undefined
 
   return {
-    props: { unparsedEvents: JSON.stringify(mottagningEvents ?? {}), criticalDates: allStartDates }
+    props: {
+      unparsedEvents: JSON.stringify(mottagningEvents ?? {}),
+      criticalDates: allStartDates,
+      calendarLoadFailed,
+    }
   }
 }
 
 interface IndexProps {
   unparsedEvents: string,
   criticalDates: string[],
+  calendarLoadFailed: boolean,
 }
 
 const Index: NextPage<IndexProps> = (props) => {
@@ -41,7 +53,10 @@ const Index: NextPage<IndexProps> = (props) => {
       <Page>
         <div className="mt-28 flex flex-col gap-6 items-center lg:flex-row lg:mt-32 lg:gap-[24vw]">
           <Countdown criticalDates={props.criticalDates} />
-          <ToDo unparsedEvents={props.unparsedEvents} />
+          <ToDo
+            unparsedEvents={props.unparsedEvents}
+            calendarLoadFailed={props.calendarLoadFailed}
+          />
         </div>
       </Page>
     </>


### PR DESCRIPTION
## Summary
- prevent Google Calendar fetch failures from crashing the homepage
- log a concise server-side error
- show `Kalendern kunde inte hämtas` instead of treating unavailable calendar data as an empty schedule