### PR TITLE
Update Outlook subscribe URL format

### DIFF
--- a/components/CalendarSubscribeModal.tsx
+++ b/components/CalendarSubscribeModal.tsx
@@ -22,7 +22,7 @@ const CalendarSubscribeModal = (props: CalendarSubscribeModalProps) => {
                 </CalendarLink>
                 <CalendarLink href={props.url}>Apple Kalender</CalendarLink>
                 <CalendarLink
-                    href={`https://outlook.office.com/owa/?path=/calendar/action/compose&rru=addsubscription&url=${encodeURIComponent(
+                    href={`https://outlook.office.com/calendar/0/addcalendar?url=${encodeURIComponent(
                         props.url
                     )}`}
                 >


### PR DESCRIPTION
Outlook updated their URL format for subscribing to a calendar which broke the link in the subscribe modal. This PR updates the URL format to the new version.

There is also an optional `name` property which prefills the "Calendar name" field. I have not implemented this however.

This is what the menu looks like after clicking the link:

<img width="387" height="507" alt="image" src="https://github.com/user-attachments/assets/3e181fd8-b66e-476d-a81f-6a73d5eb9402" />
